### PR TITLE
Allow `RichTextView` to use `ElementType` as tag prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1049,7 +1049,7 @@ Tag for displaying contents of html area input types. Takes care of processing m
 | `meta`           | `MetaData`     | Runtime data returned by fetchContent method.                                                     |
 | `customReplacer` | `Replacer`     | Function to do custom element processing. Not invoked for image, link and macro nodes. _Optional_ |
 | `className`      | `String`       | Class name to add to the root html element. _Optional_                                            |
-| `tag = 'div'`    | `String`       | Html tag to use as a root                                                                         |
+| `tag = 'section'` | `ElementType` | Element to use as a root. An html tag name, a component, or `Fragment` to render no root element at all. _Optional_ |
 
 > **TIP!** There is a utility function [richTextQuery(fieldName)](#rich-text-query) generating part of the graphql query to
 > obtain `RichTextData` for html area input types.
@@ -1060,6 +1060,16 @@ Usage:
 import RichTextView from '@enonic/nextjs-adapter/views/RichTextView';
 
 <RichTextView data={richTextData} meta={meta} tag="section" className="rich-text-view"></RichTextView>
+```
+
+To render the rich text without any wrapping element, pass `Fragment` as the tag. Note that `className` has
+nowhere to go in that case and is ignored, so apply styling to a surrounding element instead.
+
+```tsx
+import {Fragment} from 'react';
+import RichTextView from '@enonic/nextjs-adapter/views/RichTextView';
+
+<RichTextView data={richTextData} meta={meta} tag={Fragment}></RichTextView>
 ```
 
 <br/>

--- a/src/types/componentProps.ts
+++ b/src/types/componentProps.ts
@@ -11,7 +11,7 @@ import type {
     RichTextData,
     RegionTree
 } from './component';
-import type {ReactNode, ReactElement} from 'react';
+import type {ReactNode, ReactElement, ElementType} from 'react';
 
 
 export interface BaseComponentProps {
@@ -137,6 +137,6 @@ export interface RichTextViewProps {
     data: RichTextData
     meta: MetaData
     className?: string
-    tag?: string
+    tag?: ElementType
     customReplacer?: Replacer
 }

--- a/src/views/RichTextView.tsx
+++ b/src/views/RichTextView.tsx
@@ -34,7 +34,10 @@ const RichTextView = (props: RichTextViewProps) => {
         nextMeta={props.meta}
         component={component}
         className={props.className}
-        tag={props.tag}
+        // RichTextParams types tag as `string`, but it is passed straight to
+        // createElement, which accepts any ElementType — including Fragment.
+        // Cast until @enonic/react-components widens the prop upstream.
+        tag={props.tag as string}
         replacer={wrapReplacer(props.customReplacer, props.meta)}
         Macro={MacroAdapter}
         Link={LinkAdapter}

--- a/test/views/RichTextView.test.client.tsx
+++ b/test/views/RichTextView.test.client.tsx
@@ -133,5 +133,39 @@ describe('views', () => {
                     </div>`);
             });
         });
+
+        describe('tag', () => {
+
+            const data = {
+                processedHtml: '<p>one</p><p>two</p>',
+                links: [],
+                macros: [],
+                images: []
+            };
+
+            it('should wrap the content in a section by default', async () => {
+                const {container} = render(<RichTextView meta={meta} data={data}/>);
+
+                await waitFor(() => {
+                    expect(container.innerHTML).toEqual('<section><p>one</p><p>two</p></section>');
+                });
+            });
+
+            it('should use the given intrinsic tag as the wrapper', async () => {
+                const {container} = render(<RichTextView meta={meta} data={data} tag="article" className="rich"/>);
+
+                await waitFor(() => {
+                    expect(container.innerHTML).toEqual('<article class="rich"><p>one</p><p>two</p></article>');
+                });
+            });
+
+            it('should render without a wrapping element when given a Fragment', async () => {
+                const {container} = render(<RichTextView meta={meta} data={data} tag={React.Fragment}/>);
+
+                await waitFor(() => {
+                    expect(container.innerHTML).toEqual('<p>one</p><p>two</p>');
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
This makes it possible to use `Fragment` as the tag prop, making `RichTextView` not render a wrapping element at all.

Signed-off-by: Tom Arild Jakobsen <tajakobsen@gmail.com>

Closes: #1207